### PR TITLE
fixing idempotency for sshd_config file, no change when no changes, no d...

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -680,7 +680,7 @@
     regexp={{ item.rx }}
     line={{ item.ln }}
   with_items:
-    - { st: 'present', rx: "'^#?(Ciphers)?'", ln: "'Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc'" }
+    - { st: 'present', rx: "'^#?Ciphers'", ln: "'Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc'" }
     - { st: 'present', rx: "'^#?IgnoreRhosts'", ln: "'IgnoreRhosts yes'" }
     - { st: 'present', rx: "'^#?HostbasedAuthentication'", ln: "'HostbasedAuthentication no'" }
     - { st: 'present', rx: "'^#?PermitRootLogin'", ln: "'PermitRootLogin no'" }

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -14,9 +14,7 @@
   tags: [ 'cat3' , 'V-38640' , 'abrtd', 'V-38648' , 'qpidd' , 'V-38641' , 'atd' , 'V-38646' , 'oddjobd' , 'V-38644' , 'ntpdate' , 'V-38650' , 'rdisc' , 'V-38437' , 'autofs' , 'V-38669' , 'postfix' , 'V-38672' , 'netconsole' , 'V-38478' , 'rhnsd' ]
 
 - name: V-38478 Low  The Red Hat Network Service (rhnsd) service must not be running, unless using RHN or an RHN Satellite
-  shell: "chkconfig rhnsd off && service rhnsd stop"
-  register: result
-  failed_when: result.rc != 0 and result.rc != 6
+  service: name=rhnsd state=stopped enabled=false
   tags: [ 'cat3' , 'V-38478' , 'rhnsd' ]
 
 - name: V-38647 Low  The system default umask in /etc/profile must be 077
@@ -246,6 +244,6 @@
   tags: [ 'cat3' , 'V-38533' , 'tcp_timestamps' , 'kerner_parameters' , 'network' ]
 
 - name: Use strong MAC algorithms
-  lineinfile: "state=present backup=yes dest=/etc/ssh/sshd_config line='MACS    hmac-sha1,umac-64@openssh.com,hmac-ripemd160,hmac-sha2-256,hmac-sha2-512'"
+  lineinfile: "state=present backup=yes dest=/etc/ssh/sshd_config regexp='^#?MACS' line='MACS    hmac-sha1,umac-64@openssh.com,hmac-ripemd160,hmac-sha2-256,hmac-sha2-512'"
   tags: [ 'cat3' , 'ssh' , 'config' ]
   notify: restart ssh

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -14,7 +14,9 @@
   tags: [ 'cat3' , 'V-38640' , 'abrtd', 'V-38648' , 'qpidd' , 'V-38641' , 'atd' , 'V-38646' , 'oddjobd' , 'V-38644' , 'ntpdate' , 'V-38650' , 'rdisc' , 'V-38437' , 'autofs' , 'V-38669' , 'postfix' , 'V-38672' , 'netconsole' , 'V-38478' , 'rhnsd' ]
 
 - name: V-38478 Low  The Red Hat Network Service (rhnsd) service must not be running, unless using RHN or an RHN Satellite
-  service: name=rhnsd state=stopped enabled=false
+  shell: "chkconfig rhnsd off && service rhnsd stop"
+  register: result
+  failed_when: result.rc != 0 and result.rc != 6
   tags: [ 'cat3' , 'V-38478' , 'rhnsd' ]
 
 - name: V-38647 Low  The system default umask in /etc/profile must be 077


### PR DESCRIPTION
These lines in sshd_config should be unique and the file should only change when there is a change.

Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc
MACS    hmac-sha1,umac-64@openssh.com,hmac-ripemd160,hmac-sha2-256,hmac-sha2-512 