### PR TITLE
added check for samba

### DIFF
--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -113,6 +113,7 @@
 
 - name: V-38656 Low  The system must use SMB client signing for connecting to samba servers using smbclient
   lineinfile: "state=present backup=yes dest=/etc/samba/smb.conf regexp='client signing' line='client signing = mandatory' insertafter='\\[global\\]'"
+  when: samba_check.stat.exists
   tags: [ 'cat3' , 'V-38656' , 'smb' ]
   notify: restart samba
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -97,3 +97,8 @@
   failed_when: false
   when: rhel6stig_cat3
   tags: [ 'selinux' ]
+
+- name: Check for samba
+  stat: path=/etc/samba/smb.conf
+  register: samba_check
+  tags: [ 'cat3' , 'V-38656' , 'smb' ]


### PR DESCRIPTION
This should fix the samba issue when running this on CentOS. Stats for the config file and skips the samba lineinfile task should the config not exist. Fixes https://github.com/MindPointGroup/RHEL6-STIG/issues/2