### PR TITLE
nullok should not be present in /etc/pam.d/system-auth and /etc/pam.d/pa...

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ rhel6stig_pass_min_length: 14
 rhel6stig_pass_min_days: 1
 rhel6stig_pass_max_days: 60
 rhel6stig_pam_unix_params: sha512 shadow try_first_pass use_authtok remember=24
+rhel6stig_pam_auth_sufficient: pam_unix.so try_first_pass
 rhel6stig_pam_cracklib_params: try_first_pass retry=3 maxrepeat=3 minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1 difok=4
 rhel6stig_pam_faillock_params:
   - 'auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900'

--- a/files/disable-dccp.conf
+++ b/files/disable-dccp.conf
@@ -1,0 +1,1 @@
+install dccp /bin/false

--- a/files/disable-sctp.conf
+++ b/files/disable-sctp.conf
@@ -1,0 +1,1 @@
+install sctp /bin/false

--- a/files/disable-tipc.conf
+++ b/files/disable-tipc.conf
@@ -1,0 +1,1 @@
+install tipc /bin/false

--- a/files/disable-usb.conf
+++ b/files/disable-usb.conf
@@ -1,0 +1,1 @@
+install usb-storage /bin/false

--- a/tasks/cat1.yml
+++ b/tasks/cat1.yml
@@ -78,8 +78,8 @@
     - { rx: "'^(password\\s+requisite\\s+pam_cracklib.so\\s)(.*)$'", ln: "\\1{{rhel6stig_pam_cracklib_params}}", dest: '/etc/pam.d/password-auth' }
     - { rx: "'^(password\\s+sufficient\\s+pam_unix.so\\s)(.*)$'", ln: "\\1{{rhel6stig_pam_unix_params}}", dest: '/etc/pam.d/system-auth' }
     - { rx: "'^(password\\s+sufficient\\s+pam_unix.so\\s)(.*)$'", ln: "\\1{{rhel6stig_pam_unix_params}}", dest: '/etc/pam.d/password-auth' }
-    - { rx: "'^(auth\\s+sufficient\\s+pam_unix.so)(?:\\snullok)(.*?)$'", ln: "\\1\\2", dest: '/etc/pam.d/password-auth' }
-    - { rx: "'^(auth\\s+sufficient\\s+pam_unix.so)(?:\\snullok)(.*?)$'", ln: "\\1\\2", dest: '/etc/pam.d/system-auth' }
+    - { rx: "'^(auth\\s+sufficient\\s+pam_unix.so)(.*)$'", ln: "auth        sufficient    {{rhel6stig_pam_auth_sufficient}}", dest: '/etc/pam.d/system-auth' }
+    - { rx: "'^(auth\\s+sufficient\\s+pam_unix.so)(.*)$'", ln: "auth        sufficient    {{rhel6stig_pam_auth_sufficient}}", dest: '/etc/pam.d/password-auth' }
   tags: [ 'cat1' , 'cat2' , 'V-38497' , 'V-38658' , 'V-38574' , 'V-38482' , 'V-38571' , 'V-38572' , 'passwords' , 'accounts' ]
 
 - name: V-38677 High  The NFS server must not have the insecure file locking option enabled

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -139,6 +139,10 @@
   notify: unload usb-storage
   tags: [ 'cat2' , 'V-38490' , 'mobile_devices' , 'usb_devices' , 'kernel_modules' ]
 
+- name: V-38490 Medium  The operating system must enforce requirements for the connection of mobile devices to operating systems
+  copy: backup=no src=disable-usb.conf dest=/etc/modprobe.d/disable-usb.conf owner=root group=root mode=0644
+  tags: [ 'cat2' , 'V-38490' , 'mobile_devices' , 'usb_devices' , 'kernel_modules' ]
+
 - name: "V-38449 Medium  The /etc/gshadow file must have mode 0000\n    V-38443 V-38448 Medium  The /etc/gshadow file must be owned and group-owned by root"
   file: path=/etc/gshadow owner=root group=root mode=0000
   tags: [ 'cat2' , 'V-38443' , 'V-38448' , 'V-38449' , 'file_perms' ]
@@ -490,6 +494,16 @@
     - tipc
     - sctp
     - dccp
+  tags: [ 'cat2' , 'V-38517' , 'V-38515' , 'V-38514' , 'tipc' , 'sctp' , 'dccp' , 'kernel_modules' ]
+
+- name: "V-38517 Medium  The Transparent Inter-Process Communication (TIPC) protocol must be disabled unless required
+         V-38515 Medium  The Stream Control Transmission Protocol (SCTP) must be disabled unless required\n
+         V-38514 Medium  The Datagram Congestion Control Protocol (DCCP) must be disabled unless required"
+  copy: backup=no src={{ item }} dest=/etc/modprobe.d/{{ item }} owner=root group=root mode=0644
+  with_items:
+    - disable-tipc.conf
+    - disable-sctp.conf
+    - disable-dccp.conf
   tags: [ 'cat2' , 'V-38517' , 'V-38515' , 'V-38514' , 'tipc' , 'sctp' , 'dccp' , 'kernel_modules' ]
 
 - name: V-38691 Medium  The Bluetooth service must be disabled


### PR DESCRIPTION
...ssword-auth. Introducing a new variable: rhel6stig_pam_auth_sufficient. Fix for #13 SV-50298r2_rule failure in Cat 1