### PR TITLE
Adding NTP install for minimal install to pass cat2 run and fixing typo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,7 @@ rhel6stig_xwindows_required: false
 rhel6stig_ipv6_in_use: false
 
 # Whether or not TFTP is required
-# This will prevent the removal of tftp and tftp-server packges
+# This will prevent the removal of tftp and tftp-server packages
 # and configure tftp to run securely
 rhel6stig_tftp_required: false
 

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -558,6 +558,9 @@
   when: users_uid_0.stdout and not rhel6stig_fullauto
   tags: [ 'cat2' , 'V-38500' , 'accounts' ]
 
+- name: Installing NTP for V-38620 Medium/V-38621 Medium
+  yum: name=ntp state=installed
+  tags: [ 'cat2' , 'V-38620' , 'V-38621' , 'ntp' ]
 
 - name: V-38621 Medium  The system clock must be synchronized to an authoritative DoD time source
   template: src=ntp.conf.j2 dest=/etc/ntp.conf backup=yes owner=root group=root mode=0644


### PR DESCRIPTION
On a minimal installation of RHEL 6, that doesn't include installing the NTP package, the playbook run will fail with cat2 true since there is no ntpd service to restart. Also, minor typo in the comments with packges/packages.