### PR TITLE
Installing NTP and 3x Cat 3 findings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,7 @@ rhel6stig_xwindows_required: false
 rhel6stig_ipv6_in_use: false
 
 # Whether or not TFTP is required
-# This will prevent the removal of tftp and tftp-server packges
+# This will prevent the removal of tftp and tftp-server packages
 # and configure tftp to run securely
 rhel6stig_tftp_required: false
 

--- a/files/disable-dccp.conf
+++ b/files/disable-dccp.conf
@@ -1,1 +1,1 @@
-install dccp /bin/false
+install dccp /bin/true

--- a/files/disable-rds.conf
+++ b/files/disable-rds.conf
@@ -1,0 +1,1 @@
+install rds /bin/false

--- a/files/disable-rds.conf
+++ b/files/disable-rds.conf
@@ -1,1 +1,1 @@
-install rds /bin/false
+install rds /bin/true

--- a/files/disable-sctp.conf
+++ b/files/disable-sctp.conf
@@ -1,1 +1,1 @@
-install sctp /bin/false
+install sctp /bin/true

--- a/files/disable-tipc.conf
+++ b/files/disable-tipc.conf
@@ -1,1 +1,1 @@
-install tipc /bin/false
+install tipc /bin/true

--- a/files/disable-usb.conf
+++ b/files/disable-usb.conf
@@ -1,1 +1,1 @@
-install usb-storage /bin/false
+install usb-storage /bin/true

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -558,6 +558,9 @@
   when: users_uid_0.stdout and not rhel6stig_fullauto
   tags: [ 'cat2' , 'V-38500' , 'accounts' ]
 
+- name: Installing NTP for V-38620 Medium/V-38621 Medium
+  yum: name=ntp state=installed
+  tags: [ 'cat2' , 'V-38620' , 'V-38621' , 'ntp' ]
 
 - name: V-38621 Medium  The system clock must be synchronized to an authoritative DoD time source
   template: src=ntp.conf.j2 dest=/etc/ntp.conf backup=yes owner=root group=root mode=0644

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -245,7 +245,13 @@
     - disable-rds.conf
   tags: [ 'cat3' , 'V-38516' , 'rds' , 'kernel_modules' ]
 
+- name: V-38535 Low  The system must not respond to ICMPv4 sent to a broadcast address
+  sysctl: name=net.ipv4.icmp_echo_ignore_broadcasts value=1 state=present reload=yes ignoreerrors=yes
+  tags: [ 'cat3' , 'V-38535' , 'kernel_parameters' , 'network' ]
 
+- name: V-38537 Low  The system must ignore ICMPv4 bogus error responses
+  sysctl: name=net.ipv4.icmp_ignore_bogus_error_responses value=1 state=present reload=yes ignoreerrors=yes
+  tags: [ 'cat3' , 'V-38537' , 'kernel_parameters' , 'network' ]
 
 # --- BREAK --- #
 

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -239,6 +239,11 @@
   when: missing_group_check.stdout_lines and not rhel6stig_fullauto
   tags: [ 'cat3' , 'V-38681' , 'accounts' ]
 
+- name: "V-38516 Low  The Reliable Datagram Sockets (RDS) protocol must be disabled unless required"
+  copy: backup=no src={{ item }} dest=/etc/modprobe.d/{{ item }} owner=root group=root mode=0644
+  with_items:
+    - disable-rds.conf
+  tags: [ 'cat3' , 'V-38516' , 'rds' , 'kernel_modules' ]
 
 
 


### PR DESCRIPTION
On a minimal installation of RHEL 6, that doesn't include installing the NTP package, the playbook run will fail with cat2 true since there is no ntpd service to restart. Also, minor typo in the comments with packges/packages. Also closing cat 3 findings V-38516, V-38535, and V-38537.