### PR TITLE
Non-system accounts lock out bug and closing 1 cat 3 finding

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -279,7 +279,7 @@
 
 - name: "V-38496 Medium  Default system accounts, other than root, must be locked"
   command: passwd -l {{ item }}
-  with_items: unlocked_accounts.stdout_lines
+  with_items: unlocked_sys_accounts.stdout_lines
   tags: [ 'cat2' , 'V-38496' , 'accounts' ]
 
 # - name: V-38673 Medium  The operating system must ensure unauthorized, security-relevant configuration changes detected are tracked

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -253,6 +253,10 @@
   sysctl: name=net.ipv4.icmp_ignore_bogus_error_responses value=1 state=present reload=yes ignoreerrors=yes
   tags: [ 'cat3' , 'V-38537' , 'kernel_parameters' , 'network' ]
 
+- name: V-38590 Low The system must allow locking of the console screen in text mode
+  yum: name=screen state=latest
+  tags: [ 'cat3' , 'V-38590' , 'screen' ]
+
 # --- BREAK --- #
 
 - name: V-38533 Low  The system must ignore IPv4 ICMP redirect messages.

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -35,6 +35,14 @@
   always_run: yes
   tags: [ 'cat1' , 'cat2' , 'cat3' ]
 
+- name: PRELIM | Identify Unlocked Sys Accounts
+  shell: >
+   awk -F: '$1 !~ /^root$/ && $2 !~ /^[!*]/ {print $1}' /etc/shadow | xargs -I{} grep {} /etc/passwd | awk -F: '$3 < 500 {print $1}'
+  register: unlocked_sys_accounts
+  changed_when: false
+  always_run: yes
+  tags: [ 'cat1' , 'cat2' , 'cat3' ]
+
 - name: PRELIM | List system accounts
   shell: "grep -Ev '/home|root' /etc/passwd | cut -d : -f 1"
   register: system_users


### PR DESCRIPTION
For my proposed fix, I did a check for user accounts that are not root, then cross checked them against passwd for a UID < 500, since by the standards, 500+ belong to users and 499- should belong to system accounts on Red Hat systems. If someone goes against the standards, this will fail.
[Issue #25](https://github.com/MindPointGroup/RHEL6-STIG/issues/25)