### PR TITLE
This is a fix for release 8 of the STIG, and adds performance boost to auditd 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ rhel6stig_pam_cracklib_params: try_first_pass retry=3 maxrepeat=3 minlen=14 dcre
 rhel6stig_pam_faillock_params:
   - 'auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900'
   - 'auth        required      pam_faillock.so authsucc deny=3 unlock_time=604800 fail_interval=900'
+  - 'auth        required      pam_faillock.so preauth silent deny=3 unlock_time=604800 fail_interval=900'
 
 # SELinux settings
 rhel6stig_selinux_pol: targeted
@@ -168,8 +169,8 @@ rhel6stig_auditd_config:
   # NOTE: SINGLE user mode setting will break cloud systems.
   admin_space_left_action: HALT
   # auditd_failure_flag
-  # 2    Tells your system to perform an immediate shutdown without 
-  #      flushing any pending data to disk when the limits of your 
+  # 2    Tells your system to perform an immediate shutdown without
+  #      flushing any pending data to disk when the limits of your
   #      audit system are exceeded. Because this shutdown is not a clean shutdown.
   #      restrict the use of -f 2 to only the most security conscious environments
   # 1    System continues to run, issues a warning and audit stops.
@@ -183,4 +184,4 @@ rhel6stig_aide_cron:
   aide_hour: 05
   aide_day: '*'
   aide_month: '*'
-  aide_weekday: '*' 
+  aide_weekday: '*'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,6 @@ rhel6stig_pam_cracklib_params: try_first_pass retry=3 maxrepeat=3 minlen=14 dcre
 rhel6stig_pam_faillock_params:
   - 'auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900'
   - 'auth        required      pam_faillock.so authsucc deny=3 unlock_time=604800 fail_interval=900'
-  - 'auth        required      pam_faillock.so preauth silent deny=3 unlock_time=604800 fail_interval=900'
 
 # SELinux settings
 rhel6stig_selinux_pol: targeted
@@ -169,8 +168,8 @@ rhel6stig_auditd_config:
   # NOTE: SINGLE user mode setting will break cloud systems.
   admin_space_left_action: HALT
   # auditd_failure_flag
-  # 2    Tells your system to perform an immediate shutdown without
-  #      flushing any pending data to disk when the limits of your
+  # 2    Tells your system to perform an immediate shutdown without 
+  #      flushing any pending data to disk when the limits of your 
   #      audit system are exceeded. Because this shutdown is not a clean shutdown.
   #      restrict the use of -f 2 to only the most security conscious environments
   # 1    System continues to run, issues a warning and audit stops.
@@ -184,4 +183,4 @@ rhel6stig_aide_cron:
   aide_hour: 05
   aide_day: '*'
   aide_month: '*'
-  aide_weekday: '*'
+  aide_weekday: '*' 

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -454,6 +454,33 @@
     - /etc/pam.d/password-auth
   tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
 
+- name: "V-38573 Medium  The system must disable accounts after three consecutive unsuccessful login attempts\n
+        \tV-38592 Medium  The system must require administrator action to unlock an account locked by excessive failed login attempts\n
+        \tV-38501 Medium  The system must disable accounts after excessive login failures within a 15-minute interval"
+  lineinfile: >
+    dest={{ item }}
+    insertbefore='^auth\s+sufficient\s+pam_unix.so.*$'
+    regexp='^auth\s+sufficient\s+pam_unix.so.*$'
+    line="{{ rhel6stig_pam_faillock_params[2] }}"
+    follow=yes owner=root group=root mode=0644
+  with_items:
+    - /etc/pam.d/system-auth
+    - /etc/pam.d/password-auth
+  tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
+
+- name: "V-38573 Medium  The system must disable accounts after three consecutive unsuccessful login attempts\n
+        \tV-38592 Medium  The system must require administrator action to unlock an account locked by excessive failed login attempts\n
+        \tV-38501 Medium  The system must disable accounts after excessive login failures within a 15-minute interval"
+  lineinfile: >
+    dest={{ item }}
+    insertbefore='^account\s+required\s+pam_unix.so\s.*$'
+    regexp="^account\s+required\s+pam_unix.so.*$"
+    line="account required pam_faillock.so"
+    follow=yes owner=root group=root mode=0644
+  with_items:
+    - /etc/pam.d/system-auth
+    - /etc/pam.d/password-auth
+  tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
 
 - name: List all log files in /etc/rsyslog.conf
   shell: "grep /var/log/ /etc/rsyslog.conf | awk '{print $2}' | sed 's/-//'"

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -431,6 +431,34 @@
         \tV-38501 Medium  The system must disable accounts after excessive login failures within a 15-minute interval"
   lineinfile: >
     dest={{ item }}
+    insertbefore='^auth\s+sufficient\s+pam_unix.so.*$'
+    regexp='^auth\s+required\s+pam_faillock.so.*$'
+    line="{{ rhel6stig_pam_faillock_params[2] }}"
+    follow=yes owner=root group=root mode=0644
+  with_items:
+    - /etc/pam.d/system-auth
+    - /etc/pam.d/password-auth
+  tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
+
+- name: "V-38573 Medium  The system must disable accounts after three consecutive unsuccessful login attempts\n
+        \tV-38592 Medium  The system must require administrator action to unlock an account locked by excessive failed login attempts\n
+        \tV-38501 Medium  The system must disable accounts after excessive login failures within a 15-minute interval"
+  lineinfile: >
+    dest={{ item }}
+    insertbefore='^account\s+required\s+pam_unix.so.*$'
+    regexp='^account\s+required\s+pam_faillock.so.*$'
+    line="account     required      pam_faillock.so"
+    follow=yes owner=root group=root mode=0644
+  with_items:
+    - /etc/pam.d/system-auth
+    - /etc/pam.d/password-auth
+  tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
+
+- name: "V-38573 Medium  The system must disable accounts after three consecutive unsuccessful login attempts\n
+        \tV-38592 Medium  The system must require administrator action to unlock an account locked by excessive failed login attempts\n
+        \tV-38501 Medium  The system must disable accounts after excessive login failures within a 15-minute interval"
+  lineinfile: >
+    dest={{ item }}
     insertafter='^auth\s+sufficient\s+pam_unix.so\s.*$'
     regexp="^auth\s+\[default=die\]\s+pam_faillock.so.*$"
     line="{{ rhel6stig_pam_faillock_params[0] }}"
@@ -454,6 +482,19 @@
     - /etc/pam.d/password-auth
   tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
 
+- name: "V-38573 Medium  The system must disable accounts after three consecutive unsuccessful login attempts\n
+        \tV-38592 Medium  The system must require administrator action to unlock an account locked by excessive failed login attempts\n
+        \tV-38501 Medium  The system must disable accounts after excessive login failures within a 15-minute interval"
+  lineinfile: >
+    dest={{ item }}
+    insertbefore='^auth\s+sufficient\s+pam_unix.so.*$'
+    regexp='^auth\s+required\s+pam_faillock.so.*$'
+    line="{{ rhel6stig_pam_faillock_params[2] }}"
+    follow=yes owner=root group=root mode=0644
+  with_items:
+    - /etc/pam.d/system-auth
+    - /etc/pam.d/password-auth
+  tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
 
 - name: List all log files in /etc/rsyslog.conf
   shell: "grep /var/log/ /etc/rsyslog.conf | awk '{print $2}' | sed 's/-//'"

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -454,33 +454,6 @@
     - /etc/pam.d/password-auth
   tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
 
-- name: "V-38573 Medium  The system must disable accounts after three consecutive unsuccessful login attempts\n
-        \tV-38592 Medium  The system must require administrator action to unlock an account locked by excessive failed login attempts\n
-        \tV-38501 Medium  The system must disable accounts after excessive login failures within a 15-minute interval"
-  lineinfile: >
-    dest={{ item }}
-    insertbefore='^auth\s+sufficient\s+pam_unix.so.*$'
-    regexp='^auth\s+sufficient\s+pam_unix.so.*$'
-    line="{{ rhel6stig_pam_faillock_params[2] }}"
-    follow=yes owner=root group=root mode=0644
-  with_items:
-    - /etc/pam.d/system-auth
-    - /etc/pam.d/password-auth
-  tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
-
-- name: "V-38573 Medium  The system must disable accounts after three consecutive unsuccessful login attempts\n
-        \tV-38592 Medium  The system must require administrator action to unlock an account locked by excessive failed login attempts\n
-        \tV-38501 Medium  The system must disable accounts after excessive login failures within a 15-minute interval"
-  lineinfile: >
-    dest={{ item }}
-    insertbefore='^account\s+required\s+pam_unix.so\s.*$'
-    regexp="^account\s+required\s+pam_unix.so.*$"
-    line="account required pam_faillock.so"
-    follow=yes owner=root group=root mode=0644
-  with_items:
-    - /etc/pam.d/system-auth
-    - /etc/pam.d/password-auth
-  tags: [ 'cat2' , 'V-38573' , 'V-38492' , 'V-38501', 'passwords' , 'failed_logins' ]
 
 - name: List all log files in /etc/rsyslog.conf
   shell: "grep /var/log/ /etc/rsyslog.conf | awk '{print $2}' | sed 's/-//'"

--- a/templates/auditd.conf.j2
+++ b/templates/auditd.conf.j2
@@ -4,7 +4,7 @@
 log_file = /var/log/audit/audit.log
 log_format = RAW
 log_group = root
-priority_boost = 4
+priority_boost = 5
 flush = INCREMENTAL
 freq = 20
 num_logs = {{ rhel6stig_auditd_config['num_logs'] }}


### PR DESCRIPTION
SV-50393r4_rule The system must require administrator action to unlock an account locked by excessive failed login attempts.

To configure the system to lock out accounts after a number of incorrect logon attempts and require an administrator to unlock the account using "pam_faillock.so", 

modify the content of both "/etc/pam.d/system-auth" and "/etc/pam.d/password-auth" as follows: 


Add the following line immediately before the "pam_unix.so" statement in the "AUTH" section: 

auth        required      pam_faillock.so preauth silent deny=3 unlock_time=604800 fail_interval=900 

Add the following line immediately after the "pam_unix.so" statement in the "AUTH" section: 

auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900 


Add the following line immediately before the "pam_unix.so" statement in the "ACCOUNT" section: 

account     required      pam_faillock.so 