### PR TITLE
Ensure postfix is installed prior to removing sendmail

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -320,8 +320,8 @@
   tags: [ 'cat2' , 'V-38481' , 'yum' , 'updates' ]
 
 - name: V-38481 Medium  System security patches and updates must be installed and up-to-date
-  yum: 
-      name: '*' 
+  yum:
+      name: '*'
       state: latest
   when: rhel6stig_update_packages
   tags: [ 'cat2' , 'V-38481' , 'yum' , 'updates' ]
@@ -434,9 +434,27 @@
 # - name: V-38673 Medium  The operating system must ensure unauthorized, security-relevant configuration changes detected are tracked
 # - name: V-38670 Medium  The operating system must detect unauthorized changes to software and information
 
-- name: V-38671 Medium  The sendmail package must be removed
-  yum: name=sendmail state=absent
-  tags: [ 'cat2' , 'V-38671' , 'sendmail' , 'unauthorized_packages' ]
+- name: "| MEDIUM | V-38671 | PATCH |\n
+        Ensure postfix is installed"
+  yum:
+    name: postfix
+    state: present
+  tags:
+    - cat2
+    - V-38671
+    - PATCH
+
+- name: "| Medium | V-38671 | PATCH |\n
+        The sendmail package must be removed"
+  yum:
+    name: sendmail
+    state: absent
+  tags:
+    - cat2
+    - V-38671
+    - PATCH
+    - sendmail
+    - unauthorized_packages
 
 - name: V-38674 Medium  X Windows must not be enabled unless required
   lineinfile: state=present dest=/etc/inittab regexp='^id:' line='id:3:initdefault:' backup=yes

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -434,27 +434,25 @@
 # - name: V-38673 Medium  The operating system must ensure unauthorized, security-relevant configuration changes detected are tracked
 # - name: V-38670 Medium  The operating system must detect unauthorized changes to software and information
 
-- name: "| MEDIUM | V-38671 | PATCH |\n
-        Ensure postfix is installed"
+- name: "MEDIUM | V-38671 | PATCH | Ensure postfix is installed"
   yum:
-    name: postfix
-    state: present
+      name: postfix
+      state: present
   tags:
-    - cat2
-    - V-38671
-    - PATCH
+      - cat2
+      - V-38671
+      - PATCH
 
-- name: "| Medium | V-38671 | PATCH |\n
-        The sendmail package must be removed"
+- name: "MEDIUM | V-38671 | PATCH | The sendmail package must be removed"
   yum:
-    name: sendmail
-    state: absent
+      name: sendmail
+      state: absent
   tags:
-    - cat2
-    - V-38671
-    - PATCH
-    - sendmail
-    - unauthorized_packages
+      - cat2
+      - V-38671
+      - PATCH
+      - sendmail
+      - unauthorized_packages
 
 - name: V-38674 Medium  X Windows must not be enabled unless required
   lineinfile: state=present dest=/etc/inittab regexp='^id:' line='id:3:initdefault:' backup=yes


### PR DESCRIPTION
This resolves issue #27. If postfix is present when sendmail is removed, cronie
will not be removed.