### PR TITLE
SAVE_POINT: Updated cat2 and patched some bugs with the pam module

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -159,7 +159,7 @@
   lineinfile:
       regexp: "(^disk_error_action\\s*=)(\\s*)"
       line: "\\1 {{ rhel6stig_auditd_config['disk_full_action'] }}"
-      dest: /etc/audit/auditd.conf 
+      dest: /etc/audit/auditd.conf
       backrefs: yes
   tags:
       - cat2
@@ -181,7 +181,7 @@
       - audit
 
 - name: "MEDIUM | V-38465 | PATCH | Library files must have mode 0755 or less permissive"
-  file: 
+  file:
       state: file
       mode: "go-w"
       path: "{{ item }}"
@@ -207,11 +207,11 @@
       - audit
 
 - name: "MEDIUM | V-38466 | PATCH | Library files must be owned by root"
-  file: 
+  file:
       state: file
       owner: "root"
       path: "{{ item }}"
-  when: library_owner_audit.stdout 
+  when: library_owner_audit.stdout
   with_items: library_owner_audit.stdout_lines
   tags:
       - cat2
@@ -234,9 +234,9 @@
 
 - name: "MEDIUM | V-38468 | PATCH | The audit system must take appropriate action when the audit storage volume is full."
   lineinfile:
-      regexp: '(^disk_full_action\\s*=)(\\s*)' 
-      line: "\\1 {{ rhel6stig_auditd_config['disk_full_action'] }}" 
-      dest: /etc/audit/auditd.conf 
+      regexp: '(^disk_full_action\\s*=)(\\s*)'
+      line: "\\1 {{ rhel6stig_auditd_config['disk_full_action'] }}"
+      dest: /etc/audit/auditd.conf
       backrefs: yes
   tags:
       - cat2
@@ -259,7 +259,7 @@
       - audit
 
 - name: "MEDIUM | V-38469 | PATCH | All system command files must have mode 755 or less permissive"
-  file: 
+  file:
       state: file
       mode: "og-w"
       path: "{{ item }}"
@@ -286,9 +286,9 @@
 
 - name: "MEDIUM | V-38470 | PATCH | The audit system must alert designated staff members when the audit storage volume approaches capacity.."
   lineinfile:
-      regexp: '(^space_left_action\\s*=)(\\s*)' 
+      regexp: '(^space_left_action\\s*=)(\\s*)'
       line: "\\1 {{ rhel6stig_auditd_config['space_left_action'] }}"
-      dest: /etc/audit/auditd.conf 
+      dest: /etc/audit/auditd.conf
       backrefs: yes
   tags:
       - cat2
@@ -311,7 +311,7 @@
       - audit
 
 - name: "MEDIUM | V-38472 | PATCH | All system command files must be owned by root"
-  file: 
+  file:
       state: file
       owner: root
   when: sys_commands_owner_audit.stdout
@@ -337,9 +337,9 @@
 
 - name: "MEDIUM | V-38475 | PATCH | The system must require passwords to contain a minimum of 14 characters."
   lineinfile:
-      regexp: '(^PASS_MIN_LEN)\s*(\d*)' 
-      line: '\1 {{ rhel6stig_pass_min_length }}' 
-      dest: /etc/login.defs 
+      regexp: '(^PASS_MIN_LEN)\s*(\d*)'
+      line: '\1 {{ rhel6stig_pass_min_length }}'
+      dest: /etc/login.defs
       backrefs: yes
   tags:
       - cat2
@@ -362,9 +362,9 @@
 
 - name: "MEDIUM | V-38477 | PATCH | The system must require passwords to contain a minimum of 14 characters."
   lineinfile:
-      regexp: '(^PASS_MIN_DAYS)\s*(\d*)' 
-      line: '\1 {{ rhel6stig_pass_min_days }}' 
-      dest: /etc/login.defs 
+      regexp: '(^PASS_MIN_DAYS)\s*(\d*)'
+      line: '\1 {{ rhel6stig_pass_min_days }}'
+      dest: /etc/login.defs
       backrefs: yes
   tags:
       - cat2
@@ -387,9 +387,9 @@
 
 - name: "MEDIUM | V-38479 | PATCH | User passwords must be changed at least every 60 days."
   lineinfile:
-      regexp: '(^PASS_MAX_DAYS)\s*(\d*)' 
-      line: '\1 {{ rhel6stig_pass_max_days }}' 
-      dest: /etc/login.defs 
+      regexp: '(^PASS_MAX_DAYS)\s*(\d*)'
+      line: '\1 {{ rhel6stig_pass_max_days }}'
+      dest: /etc/login.defs
       backrefs: yes
   tags:
       - cat2
@@ -434,15 +434,15 @@
       - medium
       - V-38483
       - rpm
-      - yum 
+      - yum
       - audit
       - gpgcheck
 
 - name: "MEDIUM | V-38483 | PATCH | The system package management tool must cryptographically verify the authenticity of system software packages during installation."
-  replace: 
-      backup: yes 
+  replace:
+      backup: yes
       dest: '{{ item }}'
-      regexp: '^gpgcheck=0' 
+      regexp: '^gpgcheck=0'
       replace: 'gpgcheck=1'
   with_flattened:
     - /etc/yum.conf
@@ -469,8 +469,8 @@
 
 - name: "MEDIUM | V-38484 | PATCH | The operating system, upon successful logon, must display to the user the date and time of the last logon or access via ssh."
   lineinfile:
-      regexp: '(^PrintLastLog)\s*(\d*)' 
-      line: '\1 yes' 
+      regexp: '(^PrintLastLog)\s*(\d*)'
+      line: '\1 yes'
       dest: /etc/ssh/sshd_config
       backrefs: yes
 
@@ -483,7 +483,7 @@
 
 - name: "MEDIUM | V-38484 | PATCH | The operating system, upon successful logon, must display to the user the date and time of the last logon or access via ssh."
   lineinfile:
-      line: 'PrintLastLog yes' 
+      line: 'PrintLastLog yes'
       dest: /etc/ssh/sshd_config
   tags:
       - medium
@@ -537,14 +537,14 @@
       - audit
 
 - name: "MEDIUM | V-38490 | PATCH | The operating system must enforce requirements for the connection of mobile devices to operating systems"
-  copy: 
-      backup: no 
-      src: disable-usb.conf 
-      dest: /etc/modprobe.d/disable-usb.conf 
-      owner: root 
-      group: root 
+  copy:
+      backup: no
+      src: disable-usb.conf
+      dest: /etc/modprobe.d/disable-usb.conf
+      owner: root
+      group: root
       mode: "0644"
-  tags: 
+  tags:
       - medium
       - cat2
       - V-38490
@@ -570,10 +570,10 @@
     - root_access
 
 - name: "MEDIUM | V-38492 | PATCH | The system must prevent the root account from logging in from virtual consoles"
-  lineinfile: 
-      state: absent 
-      dest: /etc/securetty 
-      regexp: '^.*vc/?\d' 
+  lineinfile:
+      state: absent
+      dest: /etc/securetty
+      regexp: '^.*vc/?\d'
       backup: yes
   tags:
       - cat2
@@ -653,7 +653,7 @@
   register: unlocked_sys_accounts_audit
   changed_when: false
   always_run: yes
-  tags: 
+  tags:
       - cat2
       - medium
       - V-38496
@@ -662,13 +662,13 @@
       - system_accounts
 
 - name: "MEDIUM | V-38496 | PATCH | Default system accounts, other than root, must be locked"
-  user: 
+  user:
       name: "{{ item }}"
       state: present
       expires: 1412541480
   with_items: unlocked_sys_accounts_audit.stdout_lines
   when: unlocked_sys_accounts_audit.stdout
-  tags: 
+  tags:
       - cat2
       - medium
       - V-38496
@@ -705,8 +705,8 @@
       - V-38498
       - file_perms
 
-# V-38499 is checked but not automatically patched, please see not_automated.yml 
-# V-38500 is checked but not automatically patched, please see not_automated.yml 
+# V-38499 is checked but not automatically patched, please see not_automated.yml
+# V-38500 is checked but not automatically patched, please see not_automated.yml
 
 - name: "MEDIUM | V-38501 | AUDIT | The system must disable accounts after excessive login failures within a 15-minute interval."
   shell: grep -h pam_faillock /etc/pam.d/system-auth /etc/pam.d/password-auth | grep fail_interval | awk -F'=' '{print $NF}'
@@ -718,25 +718,11 @@
       - cat2
       - logon_settings
       - audit
-      - V-38501 
+      - V-38501
+      - pam
 
 - name: "MEDIUM | V-38501 | AUDIT | The system must disable accounts after excessive login failures within a 15-minute interval."
   shell: grep -hG '^account\s*required\s*pam_faillock\.so' /etc/pam.d/system-auth /etc/pam.d/password-auth
-  lineinfile: >
-      dest: "{{ item }}""
-      insertbefore: '^auth\s+sufficient\s+pam_unix.so.*$'
-      regexp: '^auth\s+required\s+pam_faillock.so.*$'
-      line: "{{ item }}"
-      follow: yes 
-      owner: root 
-      group: root 
-      mode: 0644
-  with_items:
-    - before_account: account required pam_faillock.so
-      before_auth: auth required pam_faillock.so preauth silent deny=3 unlock_time=604800 fail_interval=900
-      after_auth: auth [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900
-
-    - path: /etc/pam.d/password-auth
   changed_when: no
   always_run: yes
   register: login_failures_account_require
@@ -746,6 +732,7 @@
       - logon_settings
       - audit
       - V-38501
+      - pam
 
 - name: "MEDIUM | V-38501 | AUDIT | The system must disable accounts after excessive login failures within a 15-minute interval."
   assert:
@@ -760,22 +747,47 @@
       - logon_settings
       - audit
       - V-38501
+      - pam
 
 - name: "MEDIUM | V-38501 | PATCH | The system must disable accounts after excessive login failures within a 15-minute interval."
-  template:
-      src: "{{ item.src }}"
-      dest: "{{ item.dest }}"
+  pam:
+      service: "{{ item }}"
+      type: auth
+      control: required
+      pam_module: pam_faillock.so
+      before_line: auth sufficient pam_unix.so
+      arguments: preauth silent deny=3 unlock_time=604800 fail_interval=900
+      state: present
   with_items:
-      - src: system-auth.j2
-        dest: /etc/pam.d/system-auth
-      - src: password-auth.j2
-        dest: /etc/pam.d/password-auth
+      - password-auth
+      - system-auth
   tags:
       - medium
       - cat2
       - logon_settings
       - patch
       - V-38501
+      - pam
+
+- name: "MEDIUM | V-38501 | PATCH | The system must disable accounts after excessive login failures within a 15-minute interval."
+  pam:
+      service: "{{ item }}"
+      type: auth
+      control: '[default=die]'
+      pam_module: pam_faillock.so
+      after_line: auth sufficient pam_unix.so
+      arguments: authfail deny=3 unlock_time=604800 fail_interval=900
+      state: present
+  with_items:
+      - password-auth
+      - system-auth
+  tags:
+      - medium
+      - cat2
+      - logon_settings
+      - patch
+      - V-38501
+      - pam
 
 - name: "MEDIUM | V-38502 | AUDIT | The /etc/shadow file must be owned by root.\n
          MEDIUM | V-38503 | AUDIT | The /etc/shadow file must be group-owned by root.\n
@@ -783,7 +795,7 @@
   stat:
       path: /etc/shadow
   register: shadow_owner_audit
-  tags: 
+  tags:
       - medium
       - cat2
       - V-38502
@@ -796,7 +808,7 @@
       state: file
       owner: root
       path: /etc/shadow
-  tags: 
+  tags:
       - medium
       - cat2
       - V-38502
@@ -809,7 +821,7 @@
       state: file
       group: root
       path: /etc/shadow
-  tags: 
+  tags:
       - medium
       - cat2
       - V-38503
@@ -822,7 +834,7 @@
       state: file
       mode: "0000"
       path: /etc/shadow
-  tags: 
+  tags:
       - medium
       - cat2
       - V-38504
@@ -858,10 +870,10 @@
 
 - name: "MEDIUM | V-38511 | PATCH | IP forwarding for IPv4 must not be enabled unless the system is a router"
   sysctl:
-      name: net.ipv4.ip_forward 
-      value: 0 
-      state: present 
-      reload: yes 
+      name: net.ipv4.ip_forward
+      value: 0
+      state: present
+      reload: yes
       ignoreerrors: yes
   when: not rhel6stig_system_is_router
   tags:
@@ -878,7 +890,7 @@
   changed_when: no
   ignore_errors: yes
   register: iptables_audit
-  tags: 
+  tags:
       - V-38512
       - ipv4
       - network
@@ -888,11 +900,11 @@
       - patch
 
 - name: "MEDIUM | V-38512 | PATCH | The operating system must prevent public IPv4 access into an organizations internal networks except as appropriately mediated by managed interfaces employing boundary protection devices"
-  service: 
-      name: iptables 
-      enabled: yes 
+  service:
+      name: iptables
+      enabled: yes
       state: started
-  tags: 
+  tags:
       - V-38512
       - ipv4
       - network
@@ -917,14 +929,14 @@
 
 - name: "MEDIUM | V-38513 | PATCH | The systems local IPv4 firewall must implement a deny-all, allow-by-exception policy for inbound packets."
   lineinfile:
-      state: present 
-      dest: /etc/sysconfig/iptables 
-      regexp: ':INPUT' 
+      state: present
+      dest: /etc/sysconfig/iptables
+      regexp: ':INPUT'
       line: ':INPUT DROP [0:0]'
   notify: restart iptables
   tags:
       - cat2
-      - medium 
+      - medium
       - V-38513
       - ipv4
       - firewall
@@ -1099,11 +1111,11 @@
       - network
 
 - name: "MEDIUM | V-38523 | PATCH | The system must not accept IPv4 source-routed packets on any interface."
-  sysctl: 
-      name: net.ipv4.conf.all.accept_source_route 
-      value: 0 
-      state: present 
-      reload: yes 
+  sysctl:
+      name: net.ipv4.conf.all.accept_source_route
+      value: 0
+      state: present
+      reload: yes
       ignoreerrors: yes
   tags:
       - medium
@@ -1131,11 +1143,11 @@
       - network
 
 - name: "MEDIUM | V-38524 | PATCH | The system must not accept ICMPv4 redirect packets on any interface."
-  sysctl: 
+  sysctl:
       name: net.ipv4.conf.all.accept_redirects
-      value: 0 
-      state: present 
-      reload: yes 
+      value: 0
+      state: present
+      reload: yes
       ignoreerrors: yes
   tags:
       - medium
@@ -1163,11 +1175,11 @@
       - network
 
 - name: "MEDIUM | V-38526 | PATCH | The system must not accept ICMPv4 secure redirect packets on any interface."
-  sysctl: 
+  sysctl:
       name: net.ipv4.conf.all.secure_redirects
-      value: 0 
-      state: present 
-      reload: yes 
+      value: 0
+      state: present
+      reload: yes
       ignoreerrors: yes
   tags:
       - medium
@@ -1195,11 +1207,11 @@
       - network
 
 - name: "MEDIUM | V-38529 | PATCH | The system must not accept IPv4 source-routed packets by default."
-  sysctl: 
+  sysctl:
       name: net.ipv4.conf.default.accept_source_route
-      value: 0 
-      state: present 
-      reload: yes 
+      value: 0
+      state: present
+      reload: yes
       ignoreerrors: yes
   tags:
       - medium
@@ -1227,11 +1239,11 @@
       - network
 
 - name: "MEDIUM | V-38532 | PATCH | The system must not accept ICMPv4 secure redirect packets by default."
-  sysctl: 
+  sysctl:
       name: net.ipv4.conf.default.secure_redirects
-      value: 0 
-      state: present 
-      reload: yes 
+      value: 0
+      state: present
+      reload: yes
       ignoreerrors: yes
   tags:
       - medium
@@ -1259,11 +1271,11 @@
       - network
 
 - name: "MEDIUM | V-38539 | PATCH | The system must be configured to use TCP syncookies when experiencing a TCP SYN flood."
-  sysctl: 
+  sysctl:
       name: net.ipv4.tcp_syncookies
       value: 1
-      state: present 
-      reload: yes 
+      state: present
+      reload: yes
       ignoreerrors: yes
   tags:
       - medium
@@ -1291,11 +1303,11 @@
       - network
 
 - name: "MEDIUM | V-38542 | PATCH | The system must use a reverse-path filter for IPv4 network traffic when possible on all interfaces."
-  sysctl: 
+  sysctl:
       name: net.ipv4.conf.all.rp_filter
       value: 1
-      state: present 
-      reload: yes 
+      state: present
+      reload: yes
       ignoreerrors: yes
   tags:
       - medium
@@ -1323,11 +1335,11 @@
       - network
 
 - name: "MEDIUM | V-38544 | PATCH | The system must use a reverse-path filter for IPv4 network traffic when possible by default."
-  sysctl: 
+  sysctl:
       name: net.ipv4.conf.default.rp_filter
       value: 1
-      state: present 
-      reload: yes 
+      state: present
+      reload: yes
       ignoreerrors: yes
   tags:
       - medium
@@ -1337,7 +1349,7 @@
       - ipv4
       - sysctl
       - kernel_parameters
-      - network  
+      - network
 
 - name: "MEDIUM | V-38546 | AUDIT | The IPv6 protocol handler must not be bound to the network stack unless needed."
   shell: grep -rsE '^options\s*ipv6\s*disable=1' /etc/modprobe.conf /etc/modprobe.d | awk -F':' '{print $2}' | awk -F'=' '{print $2}'
@@ -1383,11 +1395,11 @@
       - network
 
 - name: "MEDIUM | V-38548 | PATCH | The system must ignore ICMPv6 redirects by default."
-  sysctl: 
+  sysctl:
       name: net.ipv6.conf.default.accept_redirects
       value: 0
-      state: present 
-      reload: yes 
+      state: present
+      reload: yes
       ignoreerrors: yes
   tags:
       - medium
@@ -1397,7 +1409,7 @@
       - ICMPv4
       - sysctl
       - kernel_parameters
-      - network  
+      - network
 
 - name: "MEDIUM | V-38549 | AUDIT | The system must employ a local IPv6 firewall.\n
          MEDIUM | V-38553 | PATCH | The operating system must prevent public IPv6 access into an organizations internal networks, except as appropriately mediated by managed interfaces employing boundary protection devices."
@@ -1419,7 +1431,7 @@
 - name: "MEDIUM | V-38549 | PATCH | The system must employ a local IPv6 firewall.\n
          MEDIUM | V-38553 | PATCH | The operating system must prevent public IPv6 access into an organizations internal networks, except as appropriately mediated by managed interfaces employing boundary protection devices."
   service:
-      name: ip6tables 
+      name: ip6tables
       state: started
       enabled: yes
   when: rhel6stig_ipv6_in_use
@@ -1450,7 +1462,7 @@
 - name: "MEDIUM | V-38555 | PATCH | The system must employ a local IPv4 firewall.\n
          MEDIUM | V-38560 | PATCH | The operating system must connect to external networks or information systems only through managed IPv4 interfaces consisting of boundary protection devices arranged in accordance with an organizational security architecture."
   service:
-      name: iptables 
+      name: iptables
       state: started
       enabled: yes
   tags:
@@ -1494,6 +1506,21 @@
       - pam
 
 - name: "MEDIUM | V-38574 | AUDIT | The system must use a FIPS 140-2 approved cryptographic hashing algorithm for generating account password hashes (system-auth)."
+  command: find /etc/pam.d/ -type f
+  changed_when: no
+  register: pamd_files
+  ignore_errors: yes
+  tags:
+      - medium
+      - cat2
+      - V-38574
+      - logon_settings
+      - accounts
+      - passwords
+      - audit
+      - pam
+
+- name: "MEDIUM | V-38574 | AUDIT | The system must use a FIPS 140-2 approved cryptographic hashing algorithm for generating account password hashes (system-auth)."
   shell: grep password -h /etc/pam.d/* | grep pam_unix.so | awk '{print $4}'
   changed_when: no
   always_run: yes
@@ -1505,11 +1532,26 @@
       - logon_settings
       - accounts
       - passwords
-      - patch
-      - pam
+      - audit
 
 - name: "MEDIUM | V-38574 | PATCH | The system must use a FIPS 140-2 approved cryptographic hashing algorithm for generating account password hashes (system-auth)."
-  
+  # The PAM module doesn't make sense for this particular rule. Lineinfile works perfectly here.
+  lineinfile:
+      dest: "{{ item }}"
+      backrefs: yes
+      regexp: (^password\s*.*pam_unix.so.*)(md5)(.*)
+      line: \1sha512\3
+      backup: yes
+    with_items: pamd_files.stdout_lines
+    tags:
+      - medium
+      - cat2
+      - V-38574
+      - logon_settings
+      - accounts
+      - passwords
+      - audit
+
 # Search for world writable files and print them out if any are found
 - name: Looking for world-writable files on the system
   command: find / -xdev -type f -perm -002


### PR DESCRIPTION
PAM Fixes include:

* The only modification that is made are to PAM module arguments. I previously had wrongly assumed that PAM entries were unique based on service, type and module, this has now been fixed to also key off the control.
* Converted file operations into Python 2.4 compatible code
* Improved documentation
* An issue where `before_line` placement was incorrectly inserting the compiled entry 2 lines prior instead of just 1.
* Some other minor fixes/improvements.

