### PR TITLE
fix for #53

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -716,6 +716,7 @@
   shell: grep -h pam_faillock /etc/pam.d/system-auth /etc/pam.d/password-auth | grep fail_interval | awk -F'=' '{print $NF}'
   changed_when: no
   always_run: yes
+  ignore_errors: yes
   register: login_failures_interval
   tags:
       - medium
@@ -729,6 +730,7 @@
   shell: grep -hG '^account\s*required\s*pam_faillock\.so' /etc/pam.d/system-auth /etc/pam.d/password-auth
   changed_when: no
   always_run: yes
+  ignore_errors: yes
   register: login_failures_account_require
   tags:
       - medium


### PR DESCRIPTION
This was the error which was fixed:

TASK: [RHEL6-STIG | MEDIUM | V-38501 | AUDIT | The system must disable accounts after excessive login failures within a 15-minute interval.] *** 
<127.0.0.1> REMOTE_MODULE command grep -hG '^account\s*required\s*pam_faillock\.so' /etc/pam.d/system-auth /etc/pam.d/password-auth #USE_SHELL
failed: [centos6] => {"changed": false, "cmd": "grep -hG '^account\\s*required\\s*pam_faillock\\.so' /etc/pam.d/system-auth /etc/pam.d/password-auth", "delta": "0:00:00.005209", "end": "2016-04-24 07:13:33.143380", "rc": 1, "start": "2016-04-24 07:13:33.138171", "stdout_lines": [], "warnings": []}

FATAL: all hosts have already failed -- aborting