### PR TITLE
BUGFIX: sysctl unknown keys

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -2074,6 +2074,7 @@
       state: present
       reload: yes
       sysctl_set: yes
+      ignoreerrors: yes
   tags:
       - cat2
       - patch


### PR DESCRIPTION
Fixed issue where the backend command `sysctl -p` was throwing an error
about unknown keys. This is due to the particular kernal modules not
being loaded but is also not a fatal thing. Added `ignoreerrors` to the
V-38597 task as is the case with the other invocations of sysctl module