### PR TITLE
fix before_line replace logic

### DIFF
--- a/library/pam.py
+++ b/library/pam.py
@@ -472,7 +472,7 @@ def pam_manager(**kwargs):
             if isinstance(current_rule_index, int) and not isinstance(current_rule_index, bool): #Here when the index of the line was 0 or 1 it was getting translated into boolean value.
                 changed = modify_rule(module, config_path, current_rule_index, config_lines, **mod_args)
 
-            if not is_full_line_present(config_lines, pam_entry):
+            if not is_full_line_present(config_lines, pam_entry) and not changed:
                 if is_full_line_present(config_lines, before_line):
                     changed = add_to_config(pam_entry, before_line, config_lines, config_path, placement='before')
                     module.exit_json(changed=changed, config_path=config_path, pam_entry=pam_entry.rstrip().expandtabs(), backup_file=backup_file)

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -392,10 +392,46 @@
       - patch
 
 # V-38522 auditd timeofday changes
+- name: "LOW | V-38522 | PATCH | The audit system must be configured to audit all attempts to alter system time through settimeofday."
+  lineinfile:
+      state: present
+      dest: /etc/audit/audit.rules
+      line: "-a always,exit -F arch={{ audit_arch }} -S settimeofday -k audit_time_rules"
+  tags:
+      - cat3
+      - low
+      - V-38522
+      - auditd
+      - settimeofday
+      - patch
 
 # V-38525 auditd stime change
+- name: "LOW | V-38527 | PATCH | The audit system must be configured to audit all attempts to alter system time through clock_settime."
+  lineinfile:
+      state: present
+      dest: /etc/audit/audit.rules
+      line: "-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k time-change"
+  tags:
+      - cat3
+      - low
+      - V-38527
+      - auditd
+      - clock_settime
+      - patch
 
-# V-38527 auditd settime
+- name: "LOW | V-38527 | PATCH | The audit system must be configured to audit all attempts to alter system time through clock_settime."
+  lineinfile:
+      state: present
+      dest: /etc/audit/audit.rules
+      line: "-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k time-change"
+  when: audit_arch == 'b64'
+  tags:
+      - cat3
+      - low
+      - V-38527
+      - auditd
+      - clock_settime
+      - patch
 
 # V-38528 log martians
 - name: "LOW | V-38528 | AUDIT The system must log Martian packets."

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -151,3 +151,10 @@
       - medium
       - V-38626
       - ldap
+
+- name: "PRELIM | Set architecture for auditd tasks"
+  set_fact:
+      audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+  tags:
+      - cat3
+      - auditd


### PR DESCRIPTION
The code did not check if modify_rule() replaced an existing line and inserted a second copy of the line if the before_line option was used.