### PR TITLE
Correct version check conditional

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,9 +11,7 @@
 - name: Check ansible version
   fail:
       msg: You must use ansible 2.1 or greater
-  when:
-      - ansible_version.major < 2
-      - ansible.version.minor < 1
+  when: ansible_version.full[:3] | float < 2.1
   tags:
       - always
 


### PR DESCRIPTION
The minor version number variable name, ansible.version, was incorrect. Additionally, the conditional did not accomplish its original goal of failing when the Ansible version is less than 2.1. This conditional statement accomplishes that goal.