### PR TITLE
Replace " for ' to expand tab characters

### DIFF
--- a/tasks/cat1.yml
+++ b/tasks/cat1.yml
@@ -259,7 +259,7 @@
           backup: yes
           dest: /etc/xinetd.d/tftp
           regexp: 'server_args\s+=\s+(/.*$)'
-          line: '\tserver_args\t\t= -s \1'
+          line: "\tserver_args\t\t= -s \\1"
           backrefs: yes
       when: "rhel6stig_tftp_required and 'tftp' in tftp_service_check.rc == 0"
       notify: reload xinetd

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -295,7 +295,7 @@
       backup: no
       dest: /etc/login.defs
       regexp: '^#?PASS_WARN_AGE'
-      line: 'PASS_WARN_AGE\t7'
+      line: "PASS_WARN_AGE\t7"
   tags:
       - cat3
       - low


### PR DESCRIPTION
When these strings are single quoted, we get a literaly '\t' string
where a TAB character is expected.  Double quoting does the expected
thing.  Tested with Ansible 2.1.0.0.