### PR TITLE
Tag mismatch on 1 of the 2 tasks for V-38592

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -1265,7 +1265,7 @@
   tags:
       - cat2
       - medium
-      - V-38573
+      - V-38572
       - logon_settings
       - accounts
       - patch

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -1265,7 +1265,7 @@
   tags:
       - cat2
       - medium
-      - V-38572
+      - V-38592
       - logon_settings
       - accounts
       - patch


### PR DESCRIPTION
Existing tag "V-38573" belongs to another set of tasks. This corrects the tag to "V-38592"