### PR TITLE
STIG alignment: passwords

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ rhel6stig_pass_max_days: 60
 rhel6stig_pass_reuse: 5
 rhel6stig_pam_unix_params: sha512 shadow try_first_pass use_authtok remember=24
 rhel6stig_pam_auth_sufficient: pam_unix.so try_first_pass
-rhel6stig_pam_cracklib_params: try_first_pass retry=3 maxrepeat=3 minlen={{ rhel6stig_pass_min_length }} dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1 difok=4
+rhel6stig_pam_cracklib_params: try_first_pass retry=3 maxrepeat=3 minlen={{ rhel6stig_pass_min_length }} dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1 difok=8
 
 # SELinux settings
 rhel6stig_selinux_pol: targeted

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -1813,9 +1813,9 @@
       service: system-auth
       backup: yes
       type: password
-      control: sufficient
-      pam_module: pam_unix.so
-      arguments: sha512 shadow try_first_pass use_authtok remember={{ rhel6stig_pass_reuse }}
+      control: requisite
+      pam_module: pam_pwhistory.so
+      arguments: use_authtok remember={{ rhel6stig_pass_reuse }}
       after_line: password requisite pam_cracklib.so
       state: present
   tags:


### PR DESCRIPTION
Per RedHat 6 STIG V1R17:

V-38572: 'The "difok" parameter will indicate how many characters must differ. The DoD requires eight characters differ during a password change. This would appear as "difok=8".'

V-38658: 'must be a line beginning with "password required pam_pwhistory.so" or "password requisite pam_pwhistory.so" and end with "remember=5"'

I'd prefer if you merged my pull request rather than squashed it.