### PR TITLE
system-auth nullok rule fixes

### DIFF
--- a/tasks/cat1.yml
+++ b/tasks/cat1.yml
@@ -41,6 +41,7 @@
 - name: "HIGH | V-38497 | PATCH | The system must not have accounts configured with blank or null passwords"
   replace:
       dest: /etc/pam.d/system-auth
+      follow: yes
       regexp: '(\s+)nullok\s*'
       replace: '\1'
   tags:

--- a/tasks/cat1.yml
+++ b/tasks/cat1.yml
@@ -41,7 +41,8 @@
 - name: "HIGH | V-38497 | PATCH | The system must not have accounts configured with blank or null passwords"
   replace:
       dest: /etc/pam.d/system-auth
-      regexp: nullok
+      regexp: '(\s+)nullok\s*'
+      replace: '\1'
   tags:
       - cat1
       - high


### PR DESCRIPTION
The first commit preserves whitespace before 'nullok', and squashes whitespace after it.  Without this commit, the options string ends up with two spaces in a row when 'nullok' is removed.

The second commit adds "follow: yes" so that the replace module will follow the symlink and operate on the actual file, usually system-auth-ac, rather that replace the symlink with a modified copy of the file.  Ansible 2.5 removes the "follow" option entirely and always modifies the linked file (as if follow=yes)

I'd prefer if you merged my pull request rather than squashed it.