### PR TITLE
auditd: fails to start if admin_space_left not less than space_left

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,6 +152,8 @@ rhel6stig_auditd_config:
   num_logs: 5
   # V-38678 - must be set to locally defined value - default 75 MB
   space_left: 75
+  # must be less than space_left
+  admin_space_left: 50
   # V-38680 - compliant options - admin account to email
   action_mail_acct: root
   # Guidance says that anything but SINGLE results in finding

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -1977,9 +1977,12 @@
 
 - name: "MEDIUM | V-38678 | PATCH | The audit system must provide a warning when allocated audit record storage volume reaches a documented percentage of maximum audit record storage capacity."
   lineinfile:
-      regexp: ^space_left\s*=.*
-      line: space_left = {{ rhel6stig_auditd_config['space_left'] }}
+      regexp: ^{{ item }}\s*=.*
+      line: "{{ item }} = {{ rhel6stig_auditd_config[item] }}"
       dest: /etc/audit/auditd.conf
+  with_items:
+      - admin_space_left
+      - space_left
   tags:
       - cat2
       - medium


### PR DESCRIPTION
if we're setting one, we should set both, or otherwise check that
both settings are consistent