### PR TITLE
only set policy for ipv6 when ipv6 actually required

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -27,6 +27,8 @@
           policy: DROP
       when: "ip6tables_input_chain_policy_check.stdout != 'DROP'"
       notify: save ip6tables rules
+  when:
+      - rhel6stig_ipv6_required
   tags:
       - cat2
       - medium


### PR DESCRIPTION
If ipv6 isn't enabled, this task causes the role to error out (or at least it did on my system).