### PR TITLE
dangerous regexp whitespace error, only match space/tab

### DIFF
--- a/tasks/cat1.yml
+++ b/tasks/cat1.yml
@@ -42,7 +42,7 @@
   replace:
       dest: /etc/pam.d/system-auth
       follow: yes
-      regexp: '(\s+)nullok\s*'
+      regexp: '([ \t]+)nullok[ \t]*'
       replace: '\1'
   tags:
       - cat1


### PR DESCRIPTION
The \s character set also matches newlines.  If nullok is the last
thing on a line, the following line is effectively removed by being
merged into the current line.  If this next line happens to be the
pam_deny.so line, auth always returns success.  The proper thing to
do here is to only match space and tab characters explicitly.