### PR TITLE
Various Fixes 2018-04-18

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -778,6 +778,10 @@
           follow: yes
           state: file
       with_items: "{{ rsyslog_logfiles.stdout_lines }}"
+      register: result
+      failed_when:
+          - result | failed
+          - not result.state == 'absent'
       tags:
           - V-38518
 
@@ -788,6 +792,10 @@
           state: file
           follow: yes
       with_items: "{{ rsyslog_logfiles.stdout_lines }}"
+      register: result
+      failed_when:
+          - result | failed
+          - not result.state == 'absent'
       tags:
           - V-38519
   tags:
@@ -1676,6 +1684,10 @@
           mode: 0600
           state: file
       with_items: "{{ rsyslog_logfiles.stdout_lines }}"
+      register: result
+      failed_when:
+          - result | failed
+          - not result.state == 'absent'
 
     # As described in https://access.redhat.com/solutions/66805, the
     # permissions for /var/log/boot.log have to be changed each time the
@@ -1684,6 +1696,10 @@
       lineinfile:
           dest: /etc/rc.d/rc.local
           line: chmod u-x,go-rwx /var/log/boot.log
+      register: result
+      failed_when:
+          - result | failed
+          - not result.state == 'absent'
   tags:
       - cat2
       - medium

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -89,9 +89,9 @@
       - audit
 
 - name: "LOW | V-38447 | PATCH | The system package management tool must verify contents of all files associated with packages."
-  command: yum reinstall -y {{ item.stdout }}
-  when: item | changed
-  with_items: "{{ rpm_integrity_audit.results }}"
+  command: yum reinstall -y {{ item }}
+  failed_when: no
+  with_items: "{{ rpm_integrity_audit.results | json_query('[?changed].stdout') | unique }}"
   tags:
       - cat3
       - low

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -2063,7 +2063,7 @@
       state: present
       dest: /etc/security/limits.conf
       regexp: '^#?\\*.*maxlogins'
-      line: '*                hard    maxlogins       {{ rhel6stig_maxlogins }}'
+      line: '*               hard    maxlogins       {{ rhel6stig_maxlogins }}'
       insertbefore: '^# End of file'
   tags:
       - cat3


### PR DESCRIPTION
- ignore missing rsyslog-generated log files
- only 'yum reinstall' once per package, not once per file per package.  (No need to reinstall a package multiple times.)
- whitespace tweak