### PR TITLE
pamd: reposition pam_faillock.so, allow more than just pam_unix.so

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -557,10 +557,10 @@
       new_control: '[default=die]'
       new_module_path: pam_faillock.so
       module_arguments: authfail deny=3 unlock_time=604800 fail_interval=900
-      state: after
+      state: before
       type: auth
-      control: sufficient
-      module_path: pam_unix.so
+      control: required
+      module_path: pam_deny.so
   with_items:
       - password-auth
       - system-auth
@@ -1017,10 +1017,10 @@
       new_control: '[default=die]'
       new_module_path: pam_faillock.so
       module_arguments: authfail deny=3 unlock_time=604800 fail_interval=900
-      state: after
+      state: before
       type: auth
-      control: sufficient
-      module_path: pam_unix.so
+      control: required
+      module_path: pam_deny.so
   with_items:
       - system-auth
       - password-auth
@@ -1294,10 +1294,10 @@
       new_control: '[default=die]'
       new_module_path: pam_faillock.so
       module_arguments: authfail deny=3 unlock_time=604800 fail_interval=900
-      state: after
+      state: before
       type: auth
-      control: sufficient
-      module_path: pam_unix.so
+      control: required
+      module_path: pam_deny.so
   with_items:
       - system-auth
       - password-auth


### PR DESCRIPTION
The remediation steps in the STIG (V-38501 and friends) would only allow pam_unix.so.
A common use case for central auth requires pam_sss.so; this change allows that while still ensuring users are locked out as appropriate.  I'm not aware of any central auth setup that would be satisfied with only pam_unix.so.  These updated remediation tasks still pass the "Check Content" in the relevant faillock rules.

From V-38439 (CAT II):
> **Check Content:** Interview the SA to determine if there is an automated system for managing user accounts, preferably integrated with an existing enterprise user management system.
>
> If there is not, this is a finding.
>
> **Fix Text:** Implement an automated system for managing user accounts that minimizes the risk of errors, either intentional or deliberate. If possible, this system should integrate with an existing enterprise user management system, such as, one based Active Directory or Kerberos.