### PR TITLE
Fix rhnsd remediation

### DIFF
--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -264,7 +264,7 @@
       enabled: no
   when:
       - "'rhnsd' in sysv_services.stdout"
-      - rhel6stig_rhnsatellite_required
+      - not rhel6stig_rhnsatellite_required
   tags:
       - cat3
       - low

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -262,6 +262,8 @@
       name: rhnsd
       state: stopped
       enabled: no
+  # rhnsd has broken initscripts, fails every time
+  ignore_errors: yes
   when:
       - "'rhnsd' in sysv_services.stdout"
       - not rhel6stig_rhnsatellite_required


### PR DESCRIPTION
This fixes two errors:

1. The role was doing the inverse of what was requested by the `rhel6stig_rhnsatellite_required` configuration item, thus never running the rule by default.
2. The rhnsd service on RHEL 6 has a broken initscript that causes the ansible service module to fail every time.  Ignore these errors. (just a workaround)  The service is disabled by the task, it just might not take effect until a reboot.