### PR TITLE
optionally audit b32 on b64

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -1023,6 +1023,26 @@
 - name: "MEDIUM | V-38580 | PATCH | The audit system must be configured to audit the loading and unloading of dynamic kernel modules."
   lineinfile:
       backup: yes
+      line: -a always,exit -F arch={{ item }} -S init_module -S delete_module -k modules
+      dest: /etc/audit/audit.rules
+      state: present
+  when:
+      - audit_arch == item or
+        item == 'b32' and rhel6stig_workaround_for_ssg_benchmark
+  with_items:
+      - b32
+      - b64
+  tags:
+      - cat2
+      - medium
+      - patch
+      - kernel
+      - auditd
+      - V-38580
+
+- name: "MEDIUM | V-38580 | PATCH | The audit system must be configured to audit the loading and unloading of dynamic kernel modules."
+  lineinfile:
+      backup: yes
       line: '{{ item }}'
       dest: /etc/audit/audit.rules
       state: present
@@ -1030,7 +1050,6 @@
       - -w /sbin/insmod -p x -k modules
       - -w /sbin/rmmod -p x -k modules
       - -w /sbin/modprobe -p x -k modules
-      - -a always,exit -F arch=b{{ ansible_architecture.split('_')[1] }} -S init_module -S delete_module -k modules
   tags:
     - cat2
     - medium

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -446,7 +446,13 @@
   lineinfile:
       state: present
       dest: /etc/audit/audit.rules
-      line: "-a always,exit -F arch={{ audit_arch }} -S settimeofday -k audit_time_rules"
+      line: "-a always,exit -F arch={{ item }} -S settimeofday -k audit_time_rules"
+  when:
+      - audit_arch == item or
+        item == 'b32' and rhel6stig_workaround_for_ssg_benchmark
+  with_items:
+      - b32
+      - b64
   tags:
       - cat3
       - low
@@ -669,11 +675,28 @@
 
 - name: "LOW | V-38540 | PATCH | The audit system must be configured to audit modifications to the systems network configuration."
   lineinfile:
+      line: "-a always,exit -F arch={{ item }} -S sethostname -S setdomainname -k audit_network_modifications"
+      state: present
+      dest: /etc/audit/audit.rules
+  when:
+      - audit_arch == item or
+        item == 'b32' and rhel6stig_workaround_for_ssg_benchmark
+  with_items:
+      - b32
+      - b64
+  tags:
+      - cat3
+      - low
+      - V-38540
+      - auditd
+      - network
+
+- name: "LOW | V-38540 | PATCH | The audit system must be configured to audit modifications to the systems network configuration."
+  lineinfile:
       line: "{{ item }}"
       state: present
       dest: /etc/audit/audit.rules
   with_items:
-      - "-a always,exit -F arch={{ audit_arch }} -S sethostname -S setdomainname -k audit_network_modifications"
       - "-w /etc/issue -p wa -k audit_network_modifications"
       - "-w /etc/issue.net -p wa -k audit_network_modifications"
       - "-w /etc/hosts -p wa -k audit_network_modifications"
@@ -1188,12 +1211,19 @@
 
 - name: "LOW | V-38568 | PATCH | The audit system must be configured to audit successful file system mounts."
   lineinfile:
-    line: "{{ item }}"
+    line: "{{ item[0] % item.1 }}"
     state: present
     dest: /etc/audit/audit.rules
-  with_items:
-    - "-a always,exit -F arch={{ audit_arch }} -S mount -F auid>=500 -F auid!=4294967295 -k export"
-    - "-a always,exit -F arch={{ audit_arch }} -S mount -F auid=0 -k export"
+  when:
+      - audit_arch == item.1 or
+        item.1 == 'b32' and rhel6stig_workaround_for_ssg_benchmark
+  with_nested:
+      -
+          - "-a always,exit -F arch=%s -S mount -F auid>=500 -F auid!=4294967295 -k export"
+          - "-a always,exit -F arch=%s -S mount -F auid=0 -k export"
+      -
+          - b32
+          - b64
   tags:
     - cat3
     - low
@@ -1218,12 +1248,19 @@
 
 - name: "LOW | V-38575 | PATCH | The audit system must be configured to audit user deletions of files and programs."
   lineinfile:
-      line: "{{ item }}"
+      line: "{{ item[0] % item.1 }}"
       state: present
       dest: /etc/audit/audit.rules
-  with_items:
-      - "-a always,exit -F arch={{ audit_arch }} -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete"
-      - "-a always,exit -F arch={{ audit_arch }} -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid=0 -k delete"
+  when:
+      - audit_arch == item.1 or
+        item.1 == 'b32' and rhel6stig_workaround_for_ssg_benchmark
+  with_nested:
+      -
+          - "-a always,exit -F arch=%s -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete"
+          - "-a always,exit -F arch=%s -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid=0 -k delete"
+      -
+          - b32
+          - b64
   tags:
       - cat3
       - low

--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -680,7 +680,7 @@
       dest: /etc/audit/audit.rules
   when:
       - audit_arch == item or
-        item == 'b32' and rhel6stig_workaround_for_ssg_benchmark
+        item == 'b32'
   with_items:
       - b32
       - b64


### PR DESCRIPTION
Audit both 32-bit and 64-bit syscalls on 64-bit systems.  The scap-security-guide project expects this everywhere.  DISA expects it on most rules.  I've made it configurable where DISA's check content doesn't explicitly require it.