### PR TITLE
pam backups cause ssg audit failures

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -966,7 +966,7 @@
           backrefs: yes
           regexp: (^password\s*.*pam_unix.so.*)(md5|sha256|blowfish|bigcrypt)(.*)
           line: \1sha512\3
-          backup: yes
+          backup: "{{ not rhel6stig_workaround_for_ssg_benchmark }}"
       with_items: "{{ pamd_files.stdout_lines }}"
   tags:
       - cat2


### PR DESCRIPTION
the backup file contains a non-compliant configuration and lives in /etc/pam.d/

This causes failures when auditing the system.


I have an alternative implementation that does:
```
shell:  mv /etc/pam.d/*'~' /root/
```
...after running the lineinfile task, instead avoiding the creation of a backup file.  Let me know if you'd prefer that version.